### PR TITLE
add optional param_preproc and grad_preproc arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-pytorch 2.0.1
+
+### Changes
+- Add optional `param_preproc` and `grad_preproc` arguments to implement custom aggregation functions or handle nan/inf values.
+
 ## neptune-pytorch 2.0.0
 
 ### Changes

--- a/src/neptune_pytorch/impl/__init__.py
+++ b/src/neptune_pytorch/impl/__init__.py
@@ -181,10 +181,7 @@ class NeptuneLogger:
             self._params_iter_tracker += 1
             if self._params_iter_tracker % self.log_freq == 0:
                 for name, param in module.named_parameters():
-                    if self._param_preproc is None:
-                        x = param.norm()
-                    else:
-                        x = self._param_preproc(param)
+                    x = param.norm() if self._param_preproc is None else self._param_preproc(param)
                     self._namespace_handler["plots"]["parameters"][name].append(x)
 
         self._params_hook_handler = self.model.register_forward_hook(hook)

--- a/src/neptune_pytorch/impl/__init__.py
+++ b/src/neptune_pytorch/impl/__init__.py
@@ -146,10 +146,7 @@ class NeptuneLogger:
             def hook(grad, name=name):
                 self._gradients_iter_tracker[name] += 1
                 if self._gradients_iter_tracker[name] % self.log_freq == 0:
-                    if self._grad_preproc is None:
-                        x = grad.norm()
-                    else:
-                        x = self._grad_preproc(grad)
+                    x = grad.norm() if self._grad_preproc is None else self._grad_preproc(grad)
                     self._namespace_handler["plots"]["gradients"][name].append(x)
 
             self._gradients_hook_handler[name] = parameter.register_hook(hook)

--- a/src/neptune_pytorch/impl/__init__.py
+++ b/src/neptune_pytorch/impl/__init__.py
@@ -141,6 +141,9 @@ class NeptuneLogger:
 
     def _add_hooks_for_grads(self):
         for name, parameter in self.model.named_parameters():
+            if not parameter.requires_grad:
+                continue
+
             self._gradients_iter_tracker[name] = 0
 
             def hook(grad, name=name):


### PR DESCRIPTION
This modification of the original code adds two additional arguments to the NeptuneLogger initialization. The `param_preproc` argument is a callable that is applied to the parameter before logging instead of the default `param.norm()`. The `grad_prerpoc` functions analogously when logging gradients.

The original motivation for these changes was to provide an easy way to handle inf/NaN values before logging. However, it can also be used to choose aggregation functions different from the tensor norm.

## Summary by Sourcery

Add optional preprocessing callbacks for parameters and gradients in NeptuneLogger to enable custom aggregation and handle NaN/Inf values.

New Features:
- Add optional `param_preproc` and `grad_preproc` arguments to NeptuneLogger for custom preprocessing of parameters and gradients before logging

Documentation:
- Update CHANGELOG.md to document new preprocessing parameters