### PR TITLE
Added Neptune 3.x + Torchwatcher support

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@latest
+      uses: actions/checkout@v3
       with:
         repository: neptune-ai/neptune-pytorch
         path: ${{ inputs.working_directory }}
@@ -21,7 +21,7 @@ runs:
       shell: bash
 
     - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@latest
+      uses: ts-graphviz/setup-graphviz@v1
       with:
         ubuntu-skip-apt-update: true
         macos-skip-brew-update: true

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@latest
       with:
         repository: neptune-ai/neptune-pytorch
         path: ${{ inputs.working_directory }}
@@ -21,7 +21,7 @@ runs:
       shell: bash
 
     - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@v1
+      uses: ts-graphviz/setup-graphviz@latest
       with:
         ubuntu-skip-apt-update: true
         macos-skip-brew-update: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.10, 3.13]
+        python-version: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@v3
 
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install build dependencies
         run: pip install poetry poetry-dynamic-versioning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.10
 
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3.13
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.10
 
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3.13
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3.13
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@latest
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@latest
         with:
           python-version: 3.10
 
@@ -25,9 +25,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.10, 3.13]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@latest
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@latest
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@latest
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@latest
         with:
           python-version: 3.10
 
@@ -56,7 +56,7 @@ jobs:
           poetry build
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@latest
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v3.13
         with:
           python-version: 3.10
 
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v3.13
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v3.13
         with:
           python-version: 3.10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@latest
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@latest
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.10
 
@@ -25,9 +25,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.10, 3.13]
     steps:
-      - uses: actions/checkout@latest
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@latest
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@latest
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@latest
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.10
 
@@ -56,7 +56,7 @@ jobs:
           poetry build
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@latest
+        uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install dependencies
         run: |
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, 3.13]
+        python-version: [3.10, 3.13]
     steps:
       - uses: actions/checkout@v2
 
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install build dependencies
         run: pip install poetry poetry-dynamic-versioning

--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ venv.bak/
 stream.bin
 
 # artifacts from integration
+data/
 *.pt
 *.png
 *.gv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,27 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1
     hooks:
       - id: isort
         args: [--settings-path, pyproject.toml]
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       - id: black
         args: [--config, pyproject.toml]
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+  - repo: local
     hooks:
-      - id: flake8
-        entry: pflake8
-        additional_dependencies: [pyproject-flake8]
+    - id: pytest
+      name: pytest
+      entry: pytest tests
+      language: python
+      types: [python]
+      pass_filenames: false
+      always_run: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 ## neptune-pytorch 3.0.0
 
-### Breaking Changes
-- **Neptune 3.x only**: This version only supports Neptune 3.x and requires a Neptune 3.x API Key.
+### Changes
+- **Neptune 3.x only**: This version only supports Neptune 3.x and requires a Neptune 3.x API token.
 - **Dropped support for logging model binaries and checkpoints**: The `log_model()` and `log_checkpoint()` methods have been removed.
 - **Removed gradient and parameter tracking flags from NeptuneLogger constructor**: The `log_gradients`, `log_parameters`, and `log_freq` parameters have been removed from the NeptuneLogger constructor. Use `log_model_internals()` parameters instead.
 - **Updated namespace structure**: Model internals are now logged under `{base_namespace}/model/internals/{prefix}/{metric_type}/{layer}/{statistic}`. For example, `pytorch_experiment/model/internals/train/activations/conv1/mean`.
 - **Changed base_namespace default**: The `base_namespace` parameter now defaults to `None` instead of `"training"`.
-- **Dropped support for Python <=3.9**
+- Dropped support for Python `<=3.9`
 -
-### New Features
-- **Enhanced model monitoring**: Added comprehensive model internals tracking with configurable statistics (mean, std, norm, min, max, var, abs_mean, hist).
+### Features
+- **Enhanced model monitoring**: Added comprehensive model internals tracking with configurable statistics: mean, std, norm, min, max, var, abs_mean, hist.
 - **Flexible layer filtering**: Added `track_layers` parameter to specify which layer types to track.
 - **Configurable statistics**: Added `tensor_stats` parameter to customize which statistics to compute for tracked tensors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## neptune-pytorch 3.0.0
+
+### Breaking Changes
+- **Neptune 3.x only**: This version only supports Neptune 3.x and requires a Neptune 3.x API Key.
+- **Dropped support for logging model binaries and checkpoints**: The `log_model()` and `log_checkpoint()` methods have been removed.
+- **Removed gradient and parameter tracking flags from NeptuneLogger constructor**: The `log_gradients`, `log_parameters`, and `log_freq` parameters have been removed from the NeptuneLogger constructor. Use `log_model_internals()` parameters instead.
+- **Updated namespace structure**: Model internals are now logged under `{base_namespace}/model/internals/{prefix}/{metric_type}/{layer}/{statistic}`. For example, `pytorch_experiment/model/internals/train/activations/conv1/mean`.
+- **Changed base_namespace default**: The `base_namespace` parameter now defaults to `None` instead of `"training"`.
+- **Dropped support for Python <=3.9**
+-
+### New Features
+- **Enhanced model monitoring**: Added comprehensive model internals tracking with configurable statistics (mean, std, norm, min, max, var, abs_mean, hist).
+- **Flexible layer filtering**: Added `track_layers` parameter to specify which layer types to track.
+- **Configurable statistics**: Added `tensor_stats` parameter to customize which statistics to compute for tracked tensors.
+
 ## neptune-pytorch 2.0.0
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ pip install -U neptune-pytorch
 - **PyTorch 1.11+**: For tensor operations and model support
 - **NumPy 1.20+**: For numerical computations
 
-## Quick Start
+## Quickstart
 
-### Basic usage
+The below quickstart example logs the following data to Neptune:
+
+- **Model architecture**: Visual diagram and summary of the neural network
+- **Training metrics**: Loss curves and epoch progress
+- **Layer activations**: Mean, std, norm, histograms for each layer
+- **Gradient analysis**: Gradient statistics to detect vanishing/exploding gradients
+- **Parameter tracking**: Weight and bias distributions over time
 
 ```python
 import torch
@@ -86,15 +92,14 @@ for epoch in range(num_epochs):
             )
 ```
 
-**Logged data in Neptune:**
+## Advanced configuration
 
-- **Model architecture**: Visual diagram and summary of the neural network
-- **Training metrics**: Loss curves and epoch progress
-- **Layer activations**: Mean, std, norm, histograms for each layer
-- **Gradient analysis**: Gradient statistics to detect vanishing/exploding gradients
-- **Parameter tracking**: Weight and bias distributions over time
+The below example demonstrates the following additional features:
 
-### Advanced configuration
+- **Layer filtering**: Only track Conv2d and Linear layers (reduces overhead)
+- **Custom statistics**: Use mean, std, hist instead of all 8 statistics
+- **Phase-specific tracking**: Different tracking strategies for train/validation
+- **Frequency control**: Track every 20 steps in training, every 50 in validation
 
 ```python
 import torch
@@ -176,12 +181,6 @@ for epoch in range(num_epochs):
                 )
 ```
 
-**Features demonstrated:**
-
-- **Layer filtering**: Only track Conv2d and Linear layers (reduces overhead)
-- **Custom statistics**: Use mean, std, hist instead of all 8 statistics
-- **Phase-specific tracking**: Different tracking strategies for train/validation
-- **Frequency control**: Track every 20 steps in training, every 50 in validation
 
 ## Features
 
@@ -316,7 +315,7 @@ NeptuneLogger(
 - `tensor_stats`: Statistics to compute (default: `["mean", "norm", "hist"]`)
 - `log_model_diagram`: Log the model summary and diagram (default: `False`)
 
-### log_model_internals
+### log_model_internals()
 
 ```python
 log_model_internals(
@@ -338,7 +337,7 @@ log_model_internals(
 
 ### Available statistics
 
-| Statistic  | Description             | Use Case                              |
+| Statistic  | Description             | Use case                              |
 | ---------- | ----------------------- | ------------------------------------- |
 | `mean`     | Mean value              | Monitor activation levels             |
 | `std`      | Standard deviation      | Detect activation variance            |
@@ -372,7 +371,7 @@ Contributions to neptune-pytorch are welcome. Here's how you can help:
 3. Make your changes and add tests
 4. Run tests: `pytest tests/`
 5. Commit your changes: `git commit -m 'Add amazing feature'`
-6. Push to the branch: `git push origin feature/amazing-feature`
+6. Push to remote: `git push origin feature/amazing-feature`
 7. Open a Pull Request
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![neptune_scale](https://img.shields.io/badge/neptune__scale-0.14.0+-orange.svg)](https://pypi.org/project/neptune-scale/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
-</div>
 
+</div>
 
 The **Neptune-PyTorch** integration simplifies tracking your PyTorch experiments with Neptune by providing automated tracking of PyTorch model internals including activations, gradients, and parameters.
 
@@ -87,6 +87,7 @@ for epoch in range(num_epochs):
 ```
 
 **Logged data in Neptune:**
+
 - **Model architecture**: Visual diagram and summary of the neural network
 - **Training metrics**: Loss curves and epoch progress
 - **Layer activations**: Mean, std, norm, histograms for each layer
@@ -176,6 +177,7 @@ for epoch in range(num_epochs):
 ```
 
 **Features demonstrated:**
+
 - **Layer filtering**: Only track Conv2d and Linear layers (reduces overhead)
 - **Custom statistics**: Use mean, std, hist instead of all 8 statistics
 - **Phase-specific tracking**: Different tracking strategies for train/validation
@@ -184,23 +186,27 @@ for epoch in range(num_epochs):
 ## Features
 
 ### Model monitoring
+
 - **Layer activations**: Track activation patterns across all layers with 8 different statistics
 - **Gradient analysis**: Monitor gradient flow and detect vanishing/exploding gradients
 - **Parameter tracking**: Log parameter statistics and distributions for model analysis
 - **Custom statistics**: Choose from mean, std, norm, min, max, var, abs_mean, and hist
 
 ### Configuration options
+
 - **Layer filtering**: Track only specific layer types (Conv2d, Linear, etc.)
 - **Phase organization**: Separate tracking for training/validation phases with custom prefixes
 - **Custom namespaces**: Organize experiments with custom folder structures
 
 ### Visualizations
+
 - **Model architecture**: Automatic model diagram generation with torchviz
 - **Distribution histograms**: 50-bin histograms for all tracked metrics
 - **Real-time monitoring**: Live tracking during training with Neptune
 - **Comparative analysis**: Easy comparison across experiments and runs
 
 ### Integration
+
 - **Minimal setup**: Simple integration with existing code
 - **PyTorch native**: Works with existing PyTorch workflows
 
@@ -263,6 +269,7 @@ The integration organizes all logged data under a clear hierarchical and customi
 **Example namespaces:**
 
 With `base_namespace="my_experiment"`:
+
 - `my_experiment/batch/loss` - Training loss
 - `my_experiment/model/summary` - Model architecture
 - `my_experiment/model/internals/activations/conv/1/mean` - Mean activation (no prefix)
@@ -270,6 +277,7 @@ With `base_namespace="my_experiment"`:
 - `my_experiment/model/internals/validation/gradients/linear1/norm` - L2 norm of gradients (with "validation" prefix)
 
 With `base_namespace=None`:
+
 - `batch/loss` - Training loss
 - `model/summary` - Model architecture
 - `model/internals/activations/conv/1/mean` - Mean activation (no prefix)
@@ -277,6 +285,7 @@ With `base_namespace=None`:
 - `model/internals/validation/gradients/linear1/norm` - L2 norm of gradients (with "validation" prefix)
 
 **Layer name handling:**
+
 - Dots in layer names are automatically replaced with forward slashes for proper namespace organization
 - Example: `seq_model.0.weight` becomes `seq_model/0/weight` in the namespace
 - Example: `module.submodule.layer` becomes `module/submodule/layer` in the namespace
@@ -293,12 +302,13 @@ NeptuneLogger(
     model: torch.nn.Module,
     base_namespace: Optional[str] = None,
     track_layers: Optional[List[Type[nn.Module]]] = None,
-    tensor_stats: Optional[List[str]] = None,
+    tensor_stats: Optional[List[TensorStatType]] = None,
     log_model_diagram: bool = False
 )
 ```
 
 **Parameters:**
+
 - `run`: Neptune run object for logging
 - `model`: PyTorch model to track
 - `base_namespace`: Optional top-level folder for organization (default: `None`)
@@ -319,6 +329,7 @@ log_model_internals(
 ```
 
 **Parameters:**
+
 - `step`: Current training step for logging
 - `track_activations`: Track layer activations (default: `True`)
 - `track_gradients`: Track layer gradients (default: `True`)
@@ -327,16 +338,16 @@ log_model_internals(
 
 ### Available statistics
 
-| Statistic | Description | Use Case |
-|-----------|-------------|----------|
-| `mean` | Mean value | Monitor activation levels |
-| `std` | Standard deviation | Detect activation variance |
-| `norm` | L2 norm | Monitor gradient/activation magnitude |
-| `min` | Minimum value | Detect dead neurons |
-| `max` | Maximum value | Detect saturation |
-| `var` | Variance | Monitor activation spread |
-| `abs_mean` | Mean of absolute values | Monitor activation strength |
-| `hist` | 50-bin histogram | Visualize distributions |
+| Statistic  | Description             | Use Case                              |
+| ---------- | ----------------------- | ------------------------------------- |
+| `mean`     | Mean value              | Monitor activation levels             |
+| `std`      | Standard deviation      | Detect activation variance            |
+| `norm`     | L2 norm                 | Monitor gradient/activation magnitude |
+| `min`      | Minimum value           | Detect dead neurons                   |
+| `max`      | Maximum value           | Detect saturation                     |
+| `var`      | Variance                | Monitor activation spread             |
+| `abs_mean` | Mean of absolute values | Monitor activation strength           |
+| `hist`     | 50-bin histogram        | Visualize distributions               |
 
 ### Namespace structure
 
@@ -360,16 +371,19 @@ log_model_internals(
 Contributions to neptune-pytorch are welcome. Here's how you can help:
 
 ### Report issues
+
 - Found a bug? [Open an issue](https://github.com/neptune-ai/neptune-pytorch/issues)
 - Include Python version, PyTorch version, and error traceback
 - Provide a minimal reproducible example
 
 ### Suggest features
+
 - Have an idea? [Create a feature request](https://github.com/neptune-ai/neptune-pytorch/issues)
 - Describe the use case and expected behavior
 - Check existing issues first to avoid duplicates
 
 ### Contribute code
+
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/amazing-feature`
 3. Make your changes and add tests
@@ -381,11 +395,13 @@ Contributions to neptune-pytorch are welcome. Here's how you can help:
 ## Support
 
 ### Get help
+
 - 📖 **Documentation**: [Neptune PyTorch Docs](https://docs.neptune.ai/integrations/pytorch/)
 - 🔧 **Troubleshooting**: [Common Issues Guide](https://docs.neptune.ai/troubleshooting)
 - 🎫 **Support Portal**: [Reach out to us](https://supportneptune.ai)
 
 ### Resources
+
 - [Neptune Documentation](https://docs.neptune.ai/)
 - [PyTorch Documentation](https://pytorch.org/docs/)
 - [Neptune Examples](https://github.com/neptune-ai/scale-examples)

--- a/README.md
+++ b/README.md
@@ -349,23 +349,6 @@ log_model_internals(
 | `abs_mean` | Mean of absolute values | Monitor activation strength           |
 | `hist`     | 50-bin histogram        | Visualize distributions               |
 
-### Namespace structure
-
-```
-{base_namespace}/                # Optional custom folder
-├── batch/                       # User-logged metrics
-│   └── loss                     # Training loss
-├── model/
-│   ├── summary                  # Model architecture summary (if enabled)
-│   ├── diagram                  # Model architecture diagram (if enabled)
-│   └── internals/               # Auto-tracked metrics
-│       ├── {prefix}/            # Optional phase (train/validation)
-│       │   ├── activations/     # Layer activations
-│       │   ├── gradients/       # Layer gradients
-│       │   └── parameters/      # Model parameters
-│       └── {metric_type}/       # Direct access (no prefix)
-```
-
 ## Contributing
 
 Contributions to neptune-pytorch are welcome. Here's how you can help:
@@ -396,9 +379,10 @@ Contributions to neptune-pytorch are welcome. Here's how you can help:
 
 ### Get help
 
-- 📖 **Documentation**: [Neptune PyTorch Docs](https://docs.neptune.ai/integrations/pytorch/)
+<!--- 📖 **Documentation**: [Neptune PyTorch Docs](https://docs.neptune.ai/integrations/pytorch/)-->
+
 - 🔧 **Troubleshooting**: [Common Issues Guide](https://docs.neptune.ai/troubleshooting)
-- 🎫 **Support Portal**: [Reach out to us](https://supportneptune.ai)
+- 🎫 **Support Portal**: [Reach out to us](https://support.neptune.ai)
 
 ### Resources
 

--- a/README.md
+++ b/README.md
@@ -1,52 +1,404 @@
 # Neptune - PyTorch integration
 
-Experiment tracking for PyTorch-trained models.
+<div align="center">
 
-## What will you get with this integration?
-
-* Log, organize, visualize, and compare ML experiments in a single place
-* Monitor model training live
-* Version and query production-ready models and associated metadata (e.g., datasets)
-* Collaborate with the team and across the organization
-
-## What will be logged to Neptune?
-
-* Training metrics
-* Model checkpoints
-* Model predictions
-* [Other metadata](https://docs.neptune.ai/logging/what_you_can_log)
-
-![image](https://docs.neptune.ai/img/app/integrations/pytorch.png)
-
-## Resources
-
-* [Documentation](https://docs.neptune.ai/integrations/pytorch/)
-* [Code example on GitHub](https://github.com/neptune-ai/examples/tree/main/integrations-and-supported-tools/pytorch/scripts)
-* [Example project in the Neptune app](https://app.neptune.ai/o/common/org/pytorch-integration/runs/details?viewId=standard-view&detailsTab=dashboard&dashboardId=9920962e-ff6a-4dea-b551-88006799b116&shortId=PYTOR1-7411&type=run)
-
-## Example
+[![PyPI version](https://badge.fury.io/py/neptune-pytorch.svg)](https://badge.fury.io/py/neptune-pytorch)
+[![neptune_scale](https://img.shields.io/badge/neptune__scale-0.14.0+-orange.svg)](https://pypi.org/project/neptune-scale/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
+</div>
 
 
+The **Neptune-PyTorch** integration simplifies tracking your PyTorch experiments with Neptune by providing automated tracking of PyTorch model internals including activations, gradients, and parameters.
+
+## Installation
+
+```bash
+pip install -U neptune-pytorch
+```
+
+## Requirements
+
+- **Neptune 3.x**: Requires a Neptune 3.x account. See the [Getting Started Guide](https://docs.neptune.ai/setup) for setup instructions.
+- **Python 3.10+**: Minimum Python version requirement
+- **PyTorch 1.11+**: For tensor operations and model support
+- **NumPy 1.20+**: For numerical computations
+
+## Quick Start
+
+### Basic usage
 
 ```python
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from neptune_scale import Run
 from neptune_pytorch import NeptuneLogger
 
-run = neptune.init_run()
+# Initialize Neptune run
+run = Run(project="your-project/experiment-tracking")
+
+# Create your PyTorch model
+model = nn.Sequential(
+    nn.Linear(784, 128),
+    nn.ReLU(),
+    nn.Linear(128, 10)
+)
+
+# Initialize Neptune logger with model tracking
 neptune_logger = NeptuneLogger(
-    run,
-    model=model,  # your torch Model()
-    log_model_diagram=True,
-    log_gradients=True,
-    log_parameters=True,
-    log_freq=30,
+    run=run,
+    model=model,
+    base_namespace="mnist_classification",  # Organizes all metrics under this folder
+    log_model_diagram=True,  # Generates model architecture diagram
+)
+
+# Training setup
+criterion = nn.CrossEntropyLoss()
+optimizer = optim.Adam(model.parameters())
+
+# Training loop with comprehensive tracking
+for epoch in range(num_epochs):
+    for batch_idx, (data, target) in enumerate(train_loader):
+        # Forward pass
+        output = model(data)
+        loss = criterion(output, target)
+
+        # Backward pass
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+        # Log training metrics to Neptune
+        run.log_metrics({
+            f"{neptune_logger.base_namespace}/batch/loss": loss.item(),
+            f"{neptune_logger.base_namespace}/epoch": epoch,
+        })
+
+        # Track model internals every 10 steps
+        if batch_idx % 10 == 0:
+            neptune_logger.log_model_internals(
+                step=batch_idx,
+                prefix="train",
+                track_activations=True,   # Monitor activation patterns
+                track_gradients=True,     # Track gradient flow
+                track_parameters=True     # Log parameter statistics
+            )
+```
+
+**Logged data in Neptune:**
+- **Model architecture**: Visual diagram and summary of the neural network
+- **Training metrics**: Loss curves and epoch progress
+- **Layer activations**: Mean, std, norm, histograms for each layer
+- **Gradient analysis**: Gradient statistics to detect vanishing/exploding gradients
+- **Parameter tracking**: Weight and bias distributions over time
+
+### Advanced configuration
+
+```python
+import torch
+import torch.nn as nn
+from neptune_scale import Run
+from neptune_pytorch import NeptuneLogger
+
+# Initialize Neptune run
+run = Run(project="your-project/advanced-tracking")
+
+# Create a more complex model (e.g., CNN for image classification)
+class CNNModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 32, 3, padding=1)
+        self.conv2 = nn.Conv2d(32, 64, 3, padding=1)
+        self.fc1 = nn.Linear(64 * 8 * 8, 128)
+        self.fc2 = nn.Linear(128, 10)
+        self.relu = nn.ReLU()
+        self.pool = nn.MaxPool2d(2)
+
+    def forward(self, x):
+        x = self.pool(self.relu(self.conv1(x)))
+        x = self.pool(self.relu(self.conv2(x)))
+        x = x.view(x.size(0), -1)
+        x = self.relu(self.fc1(x))
+        x = self.fc2(x)
+        return x
+
+model = CNNModel()
+
+# Advanced Neptune logger configuration
+neptune_logger = NeptuneLogger(
+    run=run,
+    model=model,
+    base_namespace="cnn_experiment",  # Custom organization folder
+    track_layers=[nn.Conv2d, nn.Linear],  # Only track conv and linear layers
+    tensor_stats=["mean", "norm", "hist"],  # Custom statistics (faster than default)
+    log_model_diagram=True,  # Log model summary and diagram
+)
+
+# Training with phase-specific tracking
+for epoch in range(num_epochs):
+    # Training phase - comprehensive tracking
+    model.train()
+    for batch_idx, (data, target) in enumerate(train_loader):
+        # ... your training code ...
+        output = model(data)
+        loss = criterion(output, target)
+        loss.backward()
+        optimizer.step()
+
+        # Track everything during training
+        if batch_idx % 20 == 0:  # Every 20 steps
+            neptune_logger.log_model_internals(
+                step=batch_idx,
+                prefix="train",
+                track_activations=True,   # Monitor activation patterns
+                track_gradients=True,     # Track gradient flow
+                track_parameters=True     # Log parameter statistics
+            )
+
+    # Validation phase - lightweight tracking
+    model.eval()
+    with torch.no_grad():
+        for batch_idx, (data, target) in enumerate(val_loader):
+            # ... your validation code ...
+            output = model(data)
+            val_loss = criterion(output, target)
+
+            # Only track activations during validation (faster)
+            if batch_idx % 50 == 0:  # Every 50 steps
+                neptune_logger.log_model_internals(
+                    step=batch_idx,
+                    prefix="validation",
+                    track_activations=True,   # Monitor activation patterns
+                    track_gradients=False,    # Skip gradients (no backward pass)
+                    track_parameters=False    # Skip parameters (expensive)
+                )
+```
+
+**Features demonstrated:**
+- **Layer filtering**: Only track Conv2d and Linear layers (reduces overhead)
+- **Custom statistics**: Use mean, std, hist instead of all 8 statistics
+- **Phase-specific tracking**: Different tracking strategies for train/validation
+- **Frequency control**: Track every 20 steps in training, every 50 in validation
+
+## Features
+
+### Model monitoring
+- **Layer activations**: Track activation patterns across all layers with 8 different statistics
+- **Gradient analysis**: Monitor gradient flow and detect vanishing/exploding gradients
+- **Parameter tracking**: Log parameter statistics and distributions for model analysis
+- **Custom statistics**: Choose from mean, std, norm, min, max, var, abs_mean, and hist
+
+### Configuration options
+- **Layer filtering**: Track only specific layer types (Conv2d, Linear, etc.)
+- **Phase organization**: Separate tracking for training/validation phases with custom prefixes
+- **Custom namespaces**: Organize experiments with custom folder structures
+
+### Visualizations
+- **Model architecture**: Automatic model diagram generation with torchviz
+- **Distribution histograms**: 50-bin histograms for all tracked metrics
+- **Real-time monitoring**: Live tracking during training with Neptune
+- **Comparative analysis**: Easy comparison across experiments and runs
+
+### Integration
+- **Minimal setup**: Simple integration with existing code
+- **PyTorch native**: Works with existing PyTorch workflows
+
+### Performance optimization
+
+Since parameter logging can be expensive for large models, you can control the frequency explicitly:
+
+```python
+for step in range(num_steps):
+    # ... training code ...
+
+    # Log lightweight metrics every step
+    neptune_logger.log_model_internals(
+        step=step,
+        track_activations=True,
+        track_gradients=True,
+        track_parameters=False  # Skip expensive parameter logging
+    )
+
+    # Log expensive parameters less frequently
+    if step % 100 == 0:
+        neptune_logger.log_model_internals(
+            step=step,
+            track_activations=False,
+            track_gradients=False,
+            track_parameters=True
+        )
+```
+
+### Namespace structure
+
+The integration organizes all logged data under a clear hierarchical and customizable namespace structure:
+
+```
+{base_namespace}/                   # Optional custom top-level folder
+├── batch/
+│   └── loss                        # Training loss per batch (logged by the user)
+├── model/
+│   ├── summary                     # Model architecture (if log_model_diagram=True)
+│   └── internals/                  # Model internals tracking
+│       └── {prefix}/               # Optional prefix (e.g., "train", "validation")
+│           ├── activations/        # Layer activations
+│           │   └── {layer_name}/
+│           │       ├── mean        # Mean activation value
+│           │       ├── std         # Standard deviation
+│           │       ├── norm        # L2 norm
+│           │       ├── min         # Minimum value
+│           │       ├── max         # Maximum value
+│           │       ├── var         # Variance
+│           │       ├── abs_mean    # Mean of absolute values
+│           │       └── hist        # Histogram (50 bins)
+│           ├── gradients/          # Layer gradients
+│           │   └── {layer_name}/
+│           │       └── {statistic} # Same statistics as activations
+│           └── parameters/         # Model parameters
+│               └── {layer_name}/
+│                   └── {statistic} # Same statistics as activations
+```
+
+**Example namespaces:**
+
+With `base_namespace="my_experiment"`:
+- `my_experiment/batch/loss` - Training loss
+- `my_experiment/model/summary` - Model architecture
+- `my_experiment/model/internals/activations/conv/1/mean` - Mean activation (no prefix)
+- `my_experiment/model/internals/train/activations/conv/1/mean` - Mean activation (with "train" prefix)
+- `my_experiment/model/internals/validation/gradients/linear1/norm` - L2 norm of gradients (with "validation" prefix)
+
+With `base_namespace=None`:
+- `batch/loss` - Training loss
+- `model/summary` - Model architecture
+- `model/internals/activations/conv/1/mean` - Mean activation (no prefix)
+- `model/internals/train/activations/conv/1/mean` - Mean activation (with "train" prefix)
+- `model/internals/validation/gradients/linear1/norm` - L2 norm of gradients (with "validation" prefix)
+
+**Layer name handling:**
+- Dots in layer names are automatically replaced with forward slashes for proper namespace organization
+- Example: `seq_model.0.weight` becomes `seq_model/0/weight` in the namespace
+- Example: `module.submodule.layer` becomes `module/submodule/layer` in the namespace
+
+**Available statistics:** `mean`, `std`, `norm`, `min`, `max`, `var`, `abs_mean`, `hist`
+
+## API reference
+
+### NeptuneLogger
+
+```python
+NeptuneLogger(
+    run: Run,
+    model: torch.nn.Module,
+    base_namespace: Optional[str] = None,
+    track_layers: Optional[List[Type[nn.Module]]] = None,
+    tensor_stats: Optional[List[str]] = None,
+    log_model_diagram: bool = False
 )
 ```
 
+**Parameters:**
+- `run`: Neptune run object for logging
+- `model`: PyTorch model to track
+- `base_namespace`: Optional top-level folder for organization (default: `None`)
+- `track_layers`: List of layer types to track (default: `None` = all layers)
+- `tensor_stats`: Statistics to compute (default: `["mean", "norm", "hist"]`)
+- `log_model_diagram`: Log the model summary and diagram (default: `False`)
+
+### log_model_internals
+
+```python
+log_model_internals(
+    step: int,
+    track_activations: bool = True,
+    track_gradients: bool = True,
+    track_parameters: bool = False,
+    prefix: Optional[str] = None
+)
+```
+
+**Parameters:**
+- `step`: Current training step for logging
+- `track_activations`: Track layer activations (default: `True`)
+- `track_gradients`: Track layer gradients (default: `True`)
+- `track_parameters`: Track model parameters (default: `False`)
+- `prefix`: Optional phase identifier (e.g., "train", "validation")
+
+### Available statistics
+
+| Statistic | Description | Use Case |
+|-----------|-------------|----------|
+| `mean` | Mean value | Monitor activation levels |
+| `std` | Standard deviation | Detect activation variance |
+| `norm` | L2 norm | Monitor gradient/activation magnitude |
+| `min` | Minimum value | Detect dead neurons |
+| `max` | Maximum value | Detect saturation |
+| `var` | Variance | Monitor activation spread |
+| `abs_mean` | Mean of absolute values | Monitor activation strength |
+| `hist` | 50-bin histogram | Visualize distributions |
+
+### Namespace structure
+
+```
+{base_namespace}/                # Optional custom folder
+├── batch/                       # User-logged metrics
+│   └── loss                     # Training loss
+├── model/
+│   ├── summary                  # Model architecture summary (if enabled)
+│   ├── diagram                  # Model architecture diagram (if enabled)
+│   └── internals/               # Auto-tracked metrics
+│       ├── {prefix}/            # Optional phase (train/validation)
+│       │   ├── activations/     # Layer activations
+│       │   ├── gradients/       # Layer gradients
+│       │   └── parameters/      # Model parameters
+│       └── {metric_type}/       # Direct access (no prefix)
+```
+
+## Contributing
+
+Contributions to neptune-pytorch are welcome. Here's how you can help:
+
+### Report issues
+- Found a bug? [Open an issue](https://github.com/neptune-ai/neptune-pytorch/issues)
+- Include Python version, PyTorch version, and error traceback
+- Provide a minimal reproducible example
+
+### Suggest features
+- Have an idea? [Create a feature request](https://github.com/neptune-ai/neptune-pytorch/issues)
+- Describe the use case and expected behavior
+- Check existing issues first to avoid duplicates
+
+### Contribute code
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/amazing-feature`
+3. Make your changes and add tests
+4. Run tests: `pytest tests/`
+5. Commit your changes: `git commit -m 'Add amazing feature'`
+6. Push to the branch: `git push origin feature/amazing-feature`
+7. Open a Pull Request
+
 ## Support
 
-If you got stuck or simply want to talk to us, here are your options:
+### Get help
+- 📖 **Documentation**: [Neptune PyTorch Docs](https://docs.neptune.ai/integrations/pytorch/)
+- 🔧 **Troubleshooting**: [Common Issues Guide](https://docs.neptune.ai/troubleshooting)
+- 🎫 **Support Portal**: [Reach out to us](https://supportneptune.ai)
 
-* Check our [FAQ page](https://docs.neptune.ai/getting_help).
-* You can submit bug reports, feature requests, or contributions directly to the repository.
-* Chat! In the Neptune app, click the blue message icon in the bottom-right corner and send a message. A real person will talk to you ASAP (typically very ASAP).
-* You can just shoot us an email at [support@neptune.ai](mailto:support@neptune.ai).
+### Resources
+- [Neptune Documentation](https://docs.neptune.ai/)
+- [PyTorch Documentation](https://pytorch.org/docs/)
+- [Neptune Examples](https://github.com/neptune-ai/scale-examples)
+- [Neptune Blog](https://neptune.ai/blog/)
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+
+---
+
+<div align="center">
+
+**Made with ❤️ by the Neptune team**
+
+</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,32 +9,29 @@ style = "semver"
 pattern = "default-unprefixed"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 
-# Python lack of functionalities from future versions
-importlib-metadata = { version = "*", python = "<3.8" }
-setuptools = { version = "*", python = "<3.8" }
 
-torch = ">1.8.0"
+torch = ">=1.11.0"
+numpy = ">=1.20.0"
+neptune_scale = ">=0.14.0"
 
 # dev
 pre-commit = { version = "*", optional = true }
 pytest = { version = ">=5.0", optional = true }
 pytest-cov = { version = "2.10.1", optional = true }
 pydot = { version = "*", optional = true }
-neptune = { version = ">=1.0.0", optional = true }
 torchviz = { version = "*", optional = true }
 
 [tool.poetry.extras]
-dev = ["pre-commit", "pytest", "pytest-cov", "pydot", "neptune", "torchviz"]
+dev = ["pre-commit", "pytest", "pytest-cov", "pydot", "torchviz"]
 
 [tool.poetry]
 authors = ["neptune.ai <contact@neptune.ai>"]
-description = "Neptune.ai pytorch integration library"
+description = "neptune.ai pytorch integration library"
 repository = "https://github.com/neptune-ai/neptune-pytorch"
 homepage = "https://neptune.ai/"
-documentation = "https://docs-beta.neptune.ai"
-include = ["CHANGELOG.md"]
+documentation = "https://docs.neptune.ai"
 license = "Apache License 2.0"
 name = "neptune-pytorch"
 readme = "README.md"
@@ -60,16 +57,17 @@ keywords = [
     "ML Model Registry",
     "ML Model Store",
     "ML Metadata Store",
+    "PyTorch",
 ]
 packages = [{ include = "neptune_pytorch", from = "src" }]
 
 [tool.poetry.urls]
 "Tracker" = "https://github.com/neptune-ai/neptune-pytorch/issues"
-"Documentation" = "https://docs-beta.neptune.ai"
+"Documentation" = "https://docs.neptune.ai"
 
 [tool.black]
 line-length = 120
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312', 'py313']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/src/neptune_pytorch/impl/__init__.py
+++ b/src/neptune_pytorch/impl/__init__.py
@@ -20,7 +20,6 @@ import uuid
 import warnings
 from typing import (
     List,
-    Literal,
     Optional,
     Type,
 )
@@ -30,7 +29,7 @@ import torch.nn as nn
 from neptune_scale import Run
 
 from neptune_pytorch.impl._torchwatcher import (
-    TENSOR_STATS,
+    TensorStatType,
     _TorchWatcher,
 )
 from neptune_pytorch.impl.version import __version__
@@ -121,7 +120,7 @@ class NeptuneLogger:
         base_namespace: Optional[str] = None,
         log_model_diagram: bool = False,
         track_layers: Optional[List[Type[nn.Module]]] = None,
-        tensor_stats: Optional[List[Literal[tuple(TENSOR_STATS.keys())]]] = None,
+        tensor_stats: Optional[List[TensorStatType]] = None,
     ):
         if not isinstance(run, Run):
             raise ValueError("run must be a Neptune Run object")

--- a/src/neptune_pytorch/impl/__init__.py
+++ b/src/neptune_pytorch/impl/__init__.py
@@ -18,59 +18,72 @@ __all__ = ["__version__", "NeptuneLogger"]
 import os
 import uuid
 import warnings
-import weakref
 from typing import (
+    List,
+    Literal,
     Optional,
-    Union,
+    Type,
 )
 
 import torch
+import torch.nn as nn
+from neptune_scale import Run
 
+from neptune_pytorch.impl._torchwatcher import (
+    TENSOR_STATS,
+    _TorchWatcher,
+)
 from neptune_pytorch.impl.version import __version__
 
-try:
-    # neptune-client>=1.0.0 package structure
-    from neptune import Run
-    from neptune.handler import Handler
-    from neptune.internal.utils import verify_type
-    from neptune.types import File
-except ImportError:
-    from neptune.new import Run
-    from neptune.new.handler import Handler
-    from neptune.new.integrations.utils import verify_type
-    from neptune.new.types import File
-
-IS_TORCHVIZ_AVAILABLE = True
+_IS_TORCHVIZ_AVAILABLE = True
 try:
     import torchviz
     from graphviz import ExecutableNotFound
 except ImportError:
-    IS_TORCHVIZ_AVAILABLE = False
+    _IS_TORCHVIZ_AVAILABLE = False
 
-INTEGRATION_VERSION_KEY = "source_code/integrations/neptune-pytorch"
+_INTEGRATION_VERSION_KEY = "source_code/integrations/neptune-pytorch"
 
 
 class NeptuneLogger:
     """Captures model training metadata and logs them to Neptune.
 
+    This logger provides comprehensive model monitoring capabilities including:
+    - Model diagram and summary
+    - Layer activations, gradients, and parameters tracking
+    - Configurable statistics computation (mean, std, norm, histograms, etc.)
+    - Flexible layer filtering and parameter logging frequency control
+
     Args:
-        run: Neptune run object. You can also pass a namespace handler object;
-            for example, run["test"], in which case all metadata is logged under
-            the "test" namespace inside the run.
+        run: Neptune run object.
         model: PyTorch model whose metadata will be tracked.
-        base_namespace: Namespace where all metadata logged by the callback is stored.
-        log_gradients: Whether to track the frobenius-order norm of the gradients.
-        log_parameters: Whether to track the frobenius-order norm of the parameters.
-        log_freq: How often to log the parameters/gradients norm. Applicable only
-            if `log_parameters` or `log_gradients` is True.
-        log_model_diagram: Whether to save the model visualization.
+        base_namespace: Optional custom top-level folder for organizing logged data.
+            If None, metrics are logged under a "model" folder at the root level.
+        track_layers: List of PyTorch layer types to track. If None, tracks all layers.
+        tensor_stats: List of statistics to compute for tracked tensors.
+            Available options: "mean", "std", "norm", "min", "max", "var", "abs_mean", "hist".
+            Defaults to ["mean", "norm", "hist"].
+        log_model_diagram: Whether to save the model summary and diagram.
             Requires torchviz to be installed: https://pypi.org/project/torchviz/
 
     Example:
-        import neptune
-        from neptune.integrations.pytorch import NeptuneLogger
-        run = neptune.init_run()
+        from neptune_scale import Run
+        from neptune_pytorch import NeptuneLogger
+        import torch.nn as nn
+        import torch.nn.functional as F
+
+        run = Run()
+
+        # Basic usage with default settings
         neptune_callback = NeptuneLogger(run=run, model=model)
+
+        # Advanced usage with custom configuration
+        neptune_callback = NeptuneLogger(
+            run=run,
+            model=model,
+            track_layers=[nn.Conv2d, nn.Linear],  # Only track specific layer types
+            tensor_stats=["mean", "norm", "hist"],  # Custom statistics
+        )
 
         for epoch in range(1, 4):
             model.train()
@@ -83,6 +96,18 @@ class NeptuneLogger:
                 loss.backward()
                 optimizer.step()
 
+                # Log training metrics
+                run.log_metrics({f"{neptune_callback.base_namespace}/batch/loss": loss.item()})
+
+                # Log model internals (activations, gradients, parameters)
+                neptune_callback.log_model_internals(
+                    step=batch_idx,
+                    prefix="train",
+                    track_activations=True,
+                    track_gradients=True,
+                    track_parameters=True
+                )
+
     For more, see the docs:
         Tutorial: https://docs.neptune.ai/integrations/pytorch/
         API reference: https://docs.neptune.ai/api/integrations/pytorch/
@@ -90,204 +115,122 @@ class NeptuneLogger:
 
     def __init__(
         self,
-        run: Union[Run, Handler],
+        run: Run,
         *,
         model: torch.nn.Module,
-        base_namespace="training",
+        base_namespace: Optional[str] = None,
         log_model_diagram: bool = False,
-        log_gradients: bool = False,
-        log_parameters: bool = False,
-        log_freq: int = 100,
+        track_layers: Optional[List[Type[nn.Module]]] = None,
+        tensor_stats: Optional[List[Literal[tuple(TENSOR_STATS.keys())]]] = None,
     ):
-        verify_type("run", run, (Run, Handler))
+        if not isinstance(run, Run):
+            raise ValueError("run must be a Neptune Run object")
+        if not isinstance(model, torch.nn.Module):
+            raise ValueError("model must be a PyTorch model")
 
         self.run = run
         self.model = model
         self._base_namespace = base_namespace
         self.log_model_diagram = log_model_diagram
         self.ckpt_number = 1
-        self.log_freq = log_freq
-        self._namespace_handler = self.run[base_namespace]
 
-        self._is_viz_saved = False
-        self._vis_hook_handler = None
+        self._is_diagram_saved = False
+        self._diagram_hook_handler = None
         if log_model_diagram:
-            self.run[self._base_namespace]["model"]["summary"] = str(model)
-            self._add_visualization_hook()
+            summary_key = f"{self._base_namespace}/model/summary" if self._base_namespace else "model/summary"
+            self.run.log_configs({summary_key: str(model)})
+            self._add_diagram_hook()
 
-        self.log_gradients = log_gradients
-        self._gradients_iter_tracker = {}
-        self._gradients_hook_handler = {}
-        if self.log_gradients:
-            self._add_hooks_for_grads()
-
-        self.log_parameters = log_parameters
-        self._params_iter_tracker = 0
-        self._params_hook_handler = None
-        if self.log_parameters:
-            self._add_hooks_for_params()
+        # Initialize TorchWatcher for model internals tracking
+        self._torch_watcher = _TorchWatcher(
+            model=model,
+            run=run,
+            base_namespace=base_namespace or "",
+            track_layers=track_layers,
+            tensor_stats=tensor_stats,
+        )
 
         # Log integration version
-        root_obj = self.run
-        if isinstance(self.run, Handler):
-            root_obj = self.run.get_root_obj()
+        self.run.log_configs({_INTEGRATION_VERSION_KEY: __version__})
 
-        root_obj[INTEGRATION_VERSION_KEY] = __version__
-
-    def _add_hooks_for_grads(self):
-        for name, parameter in self.model.named_parameters():
-            self._gradients_iter_tracker[name] = 0
-
-            def hook(grad, name=name):
-                self._gradients_iter_tracker[name] += 1
-                if self._gradients_iter_tracker[name] % self.log_freq == 0:
-                    self._namespace_handler["plots"]["gradients"][name].append(grad.norm())
-
-            self._gradients_hook_handler[name] = parameter.register_hook(hook)
-
-    def _add_visualization_hook(self):
-        if not IS_TORCHVIZ_AVAILABLE:
-            msg = "Skipping model visualization because no torchviz installation was found."
+    def _add_diagram_hook(self):
+        if not _IS_TORCHVIZ_AVAILABLE:
+            msg = "Skipping model diagram because no torchviz installation was found."
             warnings.warn(msg)
             return
 
         def hook(module, input, output):
-            if not self._is_viz_saved:
+            if not self._is_diagram_saved:
                 dot = torchviz.make_dot(output, params=dict(module.named_parameters()))
                 dot.format = "png"
                 # generate unique name so that multiple concurrent runs
                 # don't over-write each other.
-                viz_name = str(uuid.uuid4()) + ".png"
+                viz_name = f"{str(uuid.uuid4())}.png"
                 try:
-                    dot.render(outfile=viz_name)
-                    safe_upload_visualization(self._namespace_handler["model"], "visualization", viz_name)
+                    dot.render(outfile=viz_name, cleanup=True)
+                    _safe_upload_diagram(self.run, f"{self._base_namespace}/model/diagram", viz_name)
                 except ExecutableNotFound:
                     # This errors because `dot` renderer is not found even
                     # if python binding of `graphviz` are available.
-                    warnings.warn("Skipping model visualization because no dot (graphviz) installation was found.")
+                    warnings.warn("Skipping model diagram because no dot (graphviz) installation was found.")
 
-                self._is_viz_saved = True
+                self._is_diagram_saved = True
 
-        self._vis_hook_handler = self.model.register_forward_hook(hook)
-
-    def _add_hooks_for_params(self):
-        def hook(module, inp, output):
-            self._params_iter_tracker += 1
-            if self._params_iter_tracker % self.log_freq == 0:
-                for name, param in module.named_parameters():
-                    self._namespace_handler["plots"]["parameters"][name].append(param.norm())
-
-        self._params_hook_handler = self.model.register_forward_hook(hook)
+        self._diagram_hook_handler = self.model.register_forward_hook(hook)
 
     @property
     def base_namespace(self):
         return self._base_namespace
 
-    def log_model(self, model_name: Optional[str] = None):
-        """Uploads the model to Neptune.
-
-        The model is saved in a namespace called "model" nested under the base namespace of the run, which is
-        "training" by default.
-
-        The filename is set to `model.pt` by default, but can be customized.
+    def log_model_internals(
+        self,
+        step: int,
+        track_activations: bool = True,
+        track_gradients: bool = True,
+        track_parameters: bool = False,
+        prefix: Optional[str] = None,
+    ):
+        """
+        Log model internals using TorchWatcher.
 
         Args:
-            model_name: Name for the logged model file. The extension `.pt` is added automatically.
-
-        Example:
-            from neptune_pytorch import NeptuneLogger
-            neptune_logger = NeptuneLogger()
-            ...
-            neptune_logger.log_model()
-
-        For more, see the docs:
-            Tutorial: https://docs.neptune.ai/integrations/pytorch/
-            API reference: https://docs.neptune.ai/api/integrations/pytorch/
+            step: Logging step
+            track_activations: Whether to track activations. Defaults to True.
+            track_gradients: Whether to track gradients. Defaults to True.
+            track_parameters: Whether to track parameters. Defaults to False.
+            prefix: Optional prefix for phase organization (e.g., "train", "validation").
+                If provided, internal metrics will be logged under {base_namespace}/model/internals/{prefix}/...
         """
-        if model_name is None:
-            # Default model name
-            model_name = "model.pt"
-        else:
-            # User is not expected to add extension
-            model_name = model_name + ".pt"
-
-        safe_upload_model(self._namespace_handler["model"], model_name, self.model)
-
-    def log_checkpoint(self, checkpoint_name: Optional[str] = None):
-        """Uploads a model checkpoint to Neptune.
-
-        The checkpoint is saved in a namespace called "model/checkpoints" nested under the base namespace of the run,
-        which is "training" by default.
-
-        The filename is set to `checkpoint_<checkpoint number>.pt` by default, but can be customized.
-
-        Args:
-            checkpoint_name: Name for the logged checkpoint file.
-                If left empty, the checkpoint number used for the file name starts from 1 and is incremented
-                automatically on each call. The extension `.pt` is added automatically.
-
-        Example:
-            from neptune_pytorch import NeptuneLogger
-            neptune_logger = NeptuneLogger()
-            ...
-            for epoch in range(parameters["epochs"]):
-                ...
-                neptune_logger.log_checkpoint()
-
-        For more, see the docs:
-            Tutorial: https://docs.neptune.ai/integrations/pytorch/
-            API reference: https://docs.neptune.ai/api/integrations/pytorch/
-        """
-        if checkpoint_name is None:
-            # Default checkpoint name
-            checkpoint_name = f"checkpoint_{self.ckpt_number}.pt"
-            self.ckpt_number += 1
-        else:
-            # User is not expected to add extension
-            checkpoint_name = checkpoint_name + ".pt"
-
-        safe_upload_model(self._namespace_handler["model"]["checkpoints"], checkpoint_name, self.model)
+        self._torch_watcher.watch(
+            step=step,
+            track_activations=track_activations,
+            track_gradients=track_gradients,
+            track_parameters=track_parameters,
+            prefix=prefix,
+        )
 
     def __del__(self):
         # Remove hooks
-        if self._params_hook_handler is not None:
-            self._params_hook_handler.remove()
+        if self._diagram_hook_handler is not None:
+            self._diagram_hook_handler.remove()
 
-        for name, handler in self._gradients_hook_handler.items():
-            if handler is not None:
-                handler.remove()
-
-        if self._vis_hook_handler is not None:
-            self._vis_hook_handler.remove()
+        # Clean up TorchWatcher
+        self._torch_watcher.hm.remove_hooks()
 
 
-def safe_upload_visualization(run: Run, name: str, file_name: str):
+def _safe_upload_diagram(run: Run, name: str, file_name: str):
     # Function to safely upload a file and
     # delete the file on completion of upload.
-    # We utilise the weakref.finalize to remove
-    # the file once the stream object goes out-of-scope.
-
-    def remove(file_name):
-        os.remove(file_name)
+    try:
+        # Upload the file
+        run.assign_files({f"{name}": file_name})
+        # Wait for the upload to complete
+        run.wait_for_processing()
+    finally:
+        # Clean up the files after upload is complete
+        if os.path.exists(file_name):
+            os.remove(file_name)
         # Also remove graphviz intermediate file.
-        os.remove(file_name.replace(".png", ".gv"))
-
-    with open(file_name, "rb") as f:
-        weakref.finalize(f, remove, file_name)
-        run[name].upload(File.from_stream(f, extension="png"))
-
-
-def safe_upload_model(run: Run, name: str, model: torch.nn.Module):
-    # Function to safely upload a file and
-    # delete the file on completion of upload.
-    # We utilise the weakref.finalize to remove
-    # the file once the stream object goes out-of-scope.
-
-    torch.save(model.state_dict(), name)
-
-    def remove(file_name):
-        os.remove(file_name)
-
-    with open(name, "rb") as f:
-        weakref.finalize(f, remove, name)
-        run[name].upload(File.from_stream(f))
+        gv_file = file_name.replace(".png", ".gv")
+        if os.path.exists(gv_file):
+            os.remove(gv_file)

--- a/src/neptune_pytorch/impl/_torchwatcher.py
+++ b/src/neptune_pytorch/impl/_torchwatcher.py
@@ -1,0 +1,362 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Type,
+    Union,
+)
+
+import numpy as np
+import torch
+import torch.nn as nn
+from neptune_scale.types import Histogram
+from neptune_scale.util.logger import get_logger
+
+logger = get_logger()
+
+# Extensible dict of tensor statistics
+TENSOR_STATS = {
+    "mean": lambda x: x.mean().item(),
+    "std": lambda x: x.std().item(),
+    "norm": lambda x: x.norm().item(),
+    "min": lambda x: x.min().item(),
+    "max": lambda x: x.max().item(),
+    "var": lambda x: x.var().item(),
+    "abs_mean": lambda x: x.abs().mean().item(),
+    "hist": lambda x: torch.histogram(x, bins=50),
+}
+
+
+class _HookManager:
+    """
+    A robust hook management class for PyTorch models to track activations, gradients, and parameters.
+
+    Improvements:
+    - More comprehensive error handling
+    - Flexible hook registration
+    - Support for more layer types
+    - Configurable tracking
+    """
+
+    def __init__(self, model: nn.Module, track_layers: Optional[List[Type[nn.Module]]] = None):
+        """
+        Initialize HookManager with layer types to track.
+
+        Args:
+            model (nn.Module): The PyTorch model to track
+            track_layers (Optional[List[Type[nn.Module]]]): List of PyTorch layer types to track.
+                If None, tracks all layers in the model.
+
+        Raises:
+            TypeError: If model is not a PyTorch model
+            ValueError: If track_layers contains invalid layer types
+        """
+        if not isinstance(model, nn.Module):
+            raise TypeError("The model must be a PyTorch model")
+
+        if track_layers is not None:
+            for layer_type in track_layers:
+                if not isinstance(layer_type, type) or not issubclass(layer_type, nn.Module):
+                    raise ValueError(f"Invalid layer type: {layer_type}. Must be a subclass of nn.Module")
+
+        self.model = model
+        self.hooks: List[torch.utils.hooks.RemovableHandle] = []
+        self.activations: Dict[str, torch.Tensor] = {}
+        self.gradients: Dict[str, torch.Tensor] = {}
+        self.track_layers = track_layers
+
+    def save_activation(self, name: str):
+        """Create a forward hook to save layer activations."""
+
+        def hook(module, input, output):
+            try:
+                # Handle different output types (tensor or tuple)
+                activation = output[0] if isinstance(output, tuple) else output
+                self.activations[name] = activation.detach()
+            except Exception as e:
+                logger.warning(f"Could not save activations for {name}: {e}")
+
+        return hook
+
+    def save_gradient(self, name: str):
+        """Create a backward hook to save layer gradients."""
+
+        def hook(module, grad_input, grad_output):
+            try:
+                # Save the first gradient output
+                self.gradients[name] = grad_output[0].detach()
+            except Exception as e:
+                logger.warning(f"Could not save gradients for {name}: {e}")
+
+        return hook
+
+    def register_hooks(self, track_activations: bool = True, track_gradients: bool = True):
+        """
+        Register hooks for the model with configurable tracking.
+
+        Args:
+            track_activations (bool): Whether to track layer activations
+            track_gradients (bool): Whether to track layer gradients
+        """
+        # Clear existing hooks
+        self.remove_hooks()
+
+        # Register forward hooks for activations
+        if track_activations:
+            for name, module in self.model.named_modules():
+                # Skip the model itself
+                if name == "":
+                    continue
+                # Track all layers if track_layers is None, otherwise only specified types
+                if self.track_layers is None or any(isinstance(module, layer_type) for layer_type in self.track_layers):
+                    hook = module.register_forward_hook(self.save_activation(name))
+                    self.hooks.append(hook)
+
+        # Register backward hooks for gradients
+        if track_gradients:
+            for name, module in self.model.named_modules():
+                # Skip the model itself
+                if name == "":
+                    continue
+                # Track all layers if track_layers is None, otherwise only specified types
+                if self.track_layers is None or any(isinstance(module, layer_type) for layer_type in self.track_layers):
+                    hook = module.register_full_backward_hook(self.save_gradient(name))
+                    self.hooks.append(hook)
+
+    def remove_hooks(self):
+        """Remove all registered hooks."""
+        if hasattr(self, "hooks") and self.hooks:
+            for hook in self.hooks:
+                hook.remove()
+            self.hooks.clear()
+
+    def clear(self):
+        """Clear stored activations and gradients."""
+        self.activations.clear()
+        self.gradients.clear()
+
+    def get_activations(self) -> Dict[str, torch.Tensor]:
+        """Get stored activations."""
+        return self.activations
+
+    def get_gradients(self) -> Dict[str, torch.Tensor]:
+        """Get stored gradients."""
+        return self.gradients
+
+    def __del__(self):
+        """Ensure hooks are removed when the object is deleted."""
+        if hasattr(self, "hooks"):
+            self.remove_hooks()
+
+
+class _TorchWatcher:
+    """
+    Internal tracking mechanism for PyTorch model internals.
+    Used by NeptuneLogger for advanced model monitoring.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        run: Any,
+        base_namespace: str,
+        track_layers: Optional[List[Type[nn.Module]]] = None,
+        tensor_stats: Optional[List[Literal[tuple(TENSOR_STATS.keys())]]] = None,
+    ) -> None:
+        """
+        Initialize TorchWatcher with configuration options.
+
+        Args:
+            model (nn.Module): The PyTorch model to watch
+            run: Logging mechanism from Neptune
+            base_namespace (str): Base namespace for all logged metrics
+            track_layers (Optional[List[Type[nn.Module]]]): List of PyTorch layer types to track.
+                If None, tracks all layers in the model.
+                If specified, must contain valid PyTorch layer types.
+            tensor_stats (Optional[List[str]]): List of statistics to compute.
+                Available options: mean, std, norm, min, max, var, abs_mean, hist.
+                If None, defaults to ["mean", "norm", "hist"].
+
+        Raises:
+            TypeError: If model is not a PyTorch model
+            ValueError: If track_layers contains invalid layer types or invalid tensor_stats
+        """
+        if not isinstance(model, nn.Module):
+            raise TypeError("The model must be a PyTorch model")
+
+        # Set default tensor statistics if not provided
+        if tensor_stats is None:
+            tensor_stats = ["mean", "norm", "hist"]
+
+        # Validate tensor statistics
+        if invalid_stats := [stat for stat in tensor_stats if stat not in TENSOR_STATS]:
+            raise ValueError(
+                f"Invalid statistics requested: {invalid_stats}. "
+                f"Available statistics are: {list(TENSOR_STATS.keys())}"
+            )
+
+        self.model = model
+        self.run = run
+        self.base_namespace = base_namespace
+        self.track_layers = track_layers
+        self.hm = _HookManager(model, track_layers)
+        self.debug_metrics: Dict[str, float] = {}
+
+        self.tensor_stats = {stat: TENSOR_STATS[stat] for stat in tensor_stats}
+
+        # Default hook registration
+        self.hm.register_hooks()
+
+    def _safe_tensor_stats(self, tensor: torch.Tensor) -> Dict[str, Union[float, torch.return_types.histogram]]:
+        """
+        Safely compute tensor statistics with error handling.
+
+        Args:
+            tensor (torch.Tensor): Input tensor
+
+        Returns:
+            Dict of statistical metrics. Values can be floats for most stats or
+            torch.return_types.histogram for histogram statistics.
+        """
+        stats = {}
+        for stat_name, stat_func in self.tensor_stats.items():
+            try:
+                stats[stat_name] = stat_func(tensor)
+            except Exception as e:
+                logger.warning(f"Could not compute {stat_name} statistic: {e}")
+        return stats
+
+    def _track_metric(self, metric_type: str, data: Dict[str, torch.Tensor], prefix: Optional[str] = None):
+        """Track metrics with enhanced statistics for a given metric type.
+
+        Args:
+            metric_type (str): Type of metric being tracked (activations/gradients/parameters)
+            data (Dict[str, torch.Tensor]): Dictionary mapping layer names to tensors
+            prefix (Optional[str]): Optional prefix for phase organization (e.g., "train", "validation")
+        """
+
+        for layer, tensor in data.items():
+            if tensor is not None:
+                safe_tensor = tensor.detach().cpu() if tensor.is_cuda else tensor.detach()
+                stats = self._safe_tensor_stats(safe_tensor)
+                # Replace dots with forward slashes in layer names for proper namespace organization
+                safe_layer_name = layer.replace(".", "/")
+                for stat_name, stat_value in stats.items():
+                    if self.base_namespace:
+                        namespace = (
+                            f"{self.base_namespace}/model/internals/{prefix}/{metric_type}/{safe_layer_name}/{stat_name}"
+                            if prefix
+                            else f"{self.base_namespace}/model/internals/{metric_type}/{safe_layer_name}/{stat_name}"
+                        )
+                    elif prefix:
+                        namespace = f"model/internals/{prefix}/{metric_type}/{safe_layer_name}/{stat_name}"
+                    else:
+                        namespace = f"model/internals/{metric_type}/{safe_layer_name}/{stat_name}"
+                    self.debug_metrics[namespace] = stat_value
+
+    def track_activations(self, namespace: Optional[str] = None):
+        """Track layer activations with enhanced statistics."""
+        activations = self.hm.get_activations()
+        self._track_metric("activations", activations, namespace)
+
+    def track_gradients(self, namespace: Optional[str] = None):
+        """Track layer gradients with enhanced statistics."""
+        gradients = self.hm.get_gradients()
+        self._track_metric("gradients", gradients, namespace)
+
+    def track_parameters(self, namespace: Optional[str] = None):
+        """Track model parameters with enhanced statistics."""
+        with torch.no_grad():
+            parameters = {name: param.data for name, param in self.model.named_parameters() if param is not None}
+            self._track_metric("parameters", parameters, namespace)
+
+    def watch(
+        self,
+        step: Union[int, float],
+        track_gradients: bool = True,
+        track_parameters: bool = False,
+        track_activations: bool = True,
+        prefix: Optional[str] = None,
+    ):
+        """
+        Log debug metrics with flexible configuration.
+
+        Args:
+            step (int|float): Logging step
+            track_gradients (bool): Whether to track gradients. Defaults to True.
+            track_parameters (bool): Whether to track parameters. Defaults to False.
+            track_activations (bool): Whether to track activations. Defaults to True.
+            prefix (Optional[str]): Optional prefix for phase organization.
+                If provided, metrics will be logged under {base_namespace}/model/internals/{prefix}/...
+        """
+        # Reset metrics
+        self.debug_metrics.clear()
+
+        # Track metrics based on boolean flags
+        if track_gradients:
+            self.track_gradients(prefix)
+        if track_parameters:
+            self.track_parameters(prefix)
+        if track_activations:
+            self.track_activations(prefix)
+
+        # Process histograms with proper data type conversion
+        histogram_stats = {}
+        for attribute_name, torch_hist in self.debug_metrics.items():
+            if attribute_name.endswith("/hist"):
+                try:
+                    # torch_hist is a torch.return_types.histogram object
+                    counts_tensor = torch_hist.hist
+                    bin_edges_tensor = torch_hist.bin_edges
+
+                    # Convert to numpy arrays
+                    counts_np = counts_tensor.numpy(force=True)
+                    bin_edges_np = bin_edges_tensor.numpy(force=True)
+
+                    # Check for invalid values using numpy arrays
+                    if np.isnan(counts_np).any() or np.isinf(counts_np).any():
+                        logger.warning(f"Skipping histogram {attribute_name} due to NaN or Inf values in counts")
+                        continue
+                    if np.isnan(bin_edges_np).any() or np.isinf(bin_edges_np).any():
+                        logger.warning(f"Skipping histogram {attribute_name} due to NaN or Inf values in bin_edges")
+                        continue
+
+                    # Ensure counts are integers and bin_edges are floats
+                    counts_int = counts_np.astype(int)
+                    bin_edges_float = bin_edges_np.astype(float)
+
+                    # Convert to Python lists as Neptune expects
+                    histogram_stats[attribute_name] = Histogram(
+                        bin_edges=bin_edges_float.tolist(),
+                        counts=counts_int.tolist(),
+                    )
+                except Exception as e:
+                    logger.warning(f"Could not process histogram {attribute_name}: {e}")
+                    continue
+
+        metric_stats = {
+            attribute_name: attribute_value
+            for attribute_name, attribute_value in self.debug_metrics.items()
+            if not attribute_name.endswith("/hist")
+        }
+
+        # Log metrics
+        # Batch logging if possible, otherwise ensure atomicity
+        if histogram_stats:
+            self.run.log_metrics(data=metric_stats, step=step)
+            self.run.log_histograms(histograms=histogram_stats, step=step)
+        else:
+            self.run.log_metrics(data=metric_stats, step=step)
+
+        # Clear hooks and cached data
+        self.hm.clear()
+
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - cleanup hooks."""
+        self.hm.remove_hooks()

--- a/src/neptune_pytorch/impl/_torchwatcher.py
+++ b/src/neptune_pytorch/impl/_torchwatcher.py
@@ -27,6 +27,8 @@ TENSOR_STATS = {
     "abs_mean": lambda x: x.abs().mean().item(),
     "hist": lambda x: torch.histogram(x, bins=50),
 }
+# Create a proper type for tensor statistics
+TensorStatType = Literal["mean", "std", "norm", "min", "max", "var", "abs_mean", "hist"]
 
 
 class _HookManager:
@@ -163,7 +165,7 @@ class _TorchWatcher:
         run: Any,
         base_namespace: str,
         track_layers: Optional[List[Type[nn.Module]]] = None,
-        tensor_stats: Optional[List[Literal[tuple(TENSOR_STATS.keys())]]] = None,
+        tensor_stats: Optional[List[TensorStatType]] = None,
     ) -> None:
         """
         Initialize TorchWatcher with configuration options.
@@ -352,11 +354,3 @@ class _TorchWatcher:
 
         # Clear hooks and cached data
         self.hm.clear()
-
-    def __enter__(self):
-        """Context manager entry."""
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Context manager exit - cleanup hooks."""
-        self.hm.remove_hooks()

--- a/src/neptune_pytorch/impl/_torchwatcher.py
+++ b/src/neptune_pytorch/impl/_torchwatcher.py
@@ -204,7 +204,6 @@ class _TorchWatcher:
         self.base_namespace = base_namespace
         self.track_layers = track_layers
         self.hm = _HookManager(model, track_layers)
-        self.debug_metrics: Dict[str, float] = {}
 
         self.tensor_stats = {stat: TENSOR_STATS[stat] for stat in tensor_stats}
 
@@ -230,14 +229,23 @@ class _TorchWatcher:
                 logger.warning(f"Could not compute {stat_name} statistic: {e}")
         return stats
 
-    def _track_metric(self, metric_type: str, data: Dict[str, torch.Tensor], prefix: Optional[str] = None):
+    def _track_metric(
+        self,
+        metric_type: str,
+        data: Dict[str, torch.Tensor],
+        prefix: Optional[str] = None,
+        output: Optional[Dict] = None,
+    ):
         """Track metrics with enhanced statistics for a given metric type.
 
         Args:
             metric_type (str): Type of metric being tracked (activations/gradients/parameters)
             data (Dict[str, torch.Tensor]): Dictionary mapping layer names to tensors
             prefix (Optional[str]): Optional prefix for phase organization (e.g., "train", "validation")
+            output (Optional[Dict]): Dictionary to store the metrics. If None, creates a new dict.
         """
+        if output is None:
+            output = {}
 
         for layer, tensor in data.items():
             if tensor is not None:
@@ -256,23 +264,25 @@ class _TorchWatcher:
                         namespace = f"model/internals/{prefix}/{metric_type}/{safe_layer_name}/{stat_name}"
                     else:
                         namespace = f"model/internals/{metric_type}/{safe_layer_name}/{stat_name}"
-                    self.debug_metrics[namespace] = stat_value
+                    output[namespace] = stat_value
 
-    def track_activations(self, namespace: Optional[str] = None):
+        return output
+
+    def track_activations(self, namespace: Optional[str] = None, output: Optional[Dict] = None):
         """Track layer activations with enhanced statistics."""
         activations = self.hm.get_activations()
-        self._track_metric("activations", activations, namespace)
+        return self._track_metric("activations", activations, namespace, output)
 
-    def track_gradients(self, namespace: Optional[str] = None):
+    def track_gradients(self, namespace: Optional[str] = None, output: Optional[Dict] = None):
         """Track layer gradients with enhanced statistics."""
         gradients = self.hm.get_gradients()
-        self._track_metric("gradients", gradients, namespace)
+        return self._track_metric("gradients", gradients, namespace, output)
 
-    def track_parameters(self, namespace: Optional[str] = None):
+    def track_parameters(self, namespace: Optional[str] = None, output: Optional[Dict] = None):
         """Track model parameters with enhanced statistics."""
         with torch.no_grad():
             parameters = {name: param.data for name, param in self.model.named_parameters() if param is not None}
-            self._track_metric("parameters", parameters, namespace)
+            return self._track_metric("parameters", parameters, namespace, output)
 
     def watch(
         self,
@@ -293,20 +303,20 @@ class _TorchWatcher:
             prefix (Optional[str]): Optional prefix for phase organization.
                 If provided, metrics will be logged under {base_namespace}/model/internals/{prefix}/...
         """
-        # Reset metrics
-        self.debug_metrics.clear()
+        # Create a new dictionary for this watch call
+        metrics = {}
 
         # Track metrics based on boolean flags
         if track_gradients:
-            self.track_gradients(prefix)
+            self.track_gradients(prefix, output=metrics)
         if track_parameters:
-            self.track_parameters(prefix)
+            self.track_parameters(prefix, output=metrics)
         if track_activations:
-            self.track_activations(prefix)
+            self.track_activations(prefix, output=metrics)
 
         # Process histograms with proper data type conversion
         histogram_stats = {}
-        for attribute_name, torch_hist in self.debug_metrics.items():
+        for attribute_name, torch_hist in metrics.items():
             if attribute_name.endswith("/hist"):
                 try:
                     # torch_hist is a torch.return_types.histogram object
@@ -340,17 +350,14 @@ class _TorchWatcher:
 
         metric_stats = {
             attribute_name: attribute_value
-            for attribute_name, attribute_value in self.debug_metrics.items()
+            for attribute_name, attribute_value in metrics.items()
             if not attribute_name.endswith("/hist")
         }
 
         # Log metrics
-        # Batch logging if possible, otherwise ensure atomicity
+        self.run.log_metrics(data=metric_stats, step=step)
         if histogram_stats:
-            self.run.log_metrics(data=metric_stats, step=step)
             self.run.log_histograms(histograms=histogram_stats, step=step)
-        else:
-            self.run.log_metrics(data=metric_stats, step=step)
 
         # Clear hooks and cached data
         self.hm.clear()

--- a/src/neptune_pytorch/impl/version.py
+++ b/src/neptune_pytorch/impl/version.py
@@ -1,31 +1,22 @@
+import contextlib
+
 __all__ = ["__version__"]
 
-import sys
+from importlib.metadata import (
+    PackageNotFoundError,
+    version,
+)
 from importlib.util import find_spec
 
-if sys.version_info >= (3, 8):
-    from importlib.metadata import (
-        PackageNotFoundError,
-        version,
-    )
-else:
-    from importlib_metadata import (
-        PackageNotFoundError,
-        version,
-    )
-
-if not (find_spec("neptune") or find_spec("neptune-client")):
+if not (find_spec("neptune_scale")):
     msg = """
-            The Neptune client library was not found.
+            The Neptune Scale client library was not found.
 
-            Install the neptune package with
-                `pip install neptune`
+            Install the neptune-scale package with
+                `pip install -U neptune-scale`
 
-            Need help? -> https://docs.neptune.ai/setup/installation/"""
+            Need help? -> https://docs.neptune.ai/setup"""
     raise PackageNotFoundError(msg)
 
-try:
+with contextlib.suppress(PackageNotFoundError):
     __version__ = version("neptune-pytorch")
-except PackageNotFoundError:
-    # package is not installed
-    pass

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,15 +1,11 @@
 from __future__ import print_function
 
-try:
-    # neptune-client>=1.0.0 package structure
-    from neptune import init_run
-except ImportError:
-    # neptune-client=0.9.0+ package structure
-    from neptune.new import init_run
+from unittest.mock import Mock
 
 import torch
 import torch.nn.functional as F
 import torch.optim as optim
+from neptune_scale import Run
 
 from neptune_pytorch import NeptuneLogger
 
@@ -25,15 +21,24 @@ def test_e2e(model, dataset):
     model = model.to(device)
     optimizer = optim.Adadelta(model.parameters(), lr=0.001)
 
-    run = init_run()
+    # Mock the Neptune run object
+    run = Mock(spec=Run)
+    run.log_metrics = Mock()
+    run.log_histograms = Mock()
+    run.log_configs = Mock()
+    run.assign_files = Mock()
+    run.wait_for_processing = Mock()
 
     npt_logger = NeptuneLogger(
-        run, model=model, log_model_diagram=True, log_gradients=True, log_parameters=True, log_freq=3
+        run,
+        model=model,
+        base_namespace="test_experiment",
+        log_model_diagram=True,
     )
 
-    for epoch in range(1, 4):
+    for _ in range(1, 4):
         model.train()
-        for batch_idx, (data, target) in enumerate(train_loader):
+        for data, target in train_loader:
             data, target = data.to(device), target.to(device)
             optimizer.zero_grad()
             output = model(data)
@@ -42,17 +47,67 @@ def test_e2e(model, dataset):
             loss.backward()
             optimizer.step()
 
-            run[npt_logger.base_namespace]["batch/loss"].append(loss.item())
+            run.log_metrics({f"{npt_logger.base_namespace}/batch/loss": loss.item()})
+            npt_logger.log_model_internals(
+                step=0,
+                prefix="train",
+                track_activations=True,
+                track_gradients=True,
+                track_parameters=True,
+            )
 
-        npt_logger.log_checkpoint()
+    # Verify that the correct logging methods were called
+    # Check that log_metrics was called for batch loss
+    assert run.log_metrics.call_count >= 1
 
-    # Save final model
-    npt_logger.log_model("model")
+    # Check that log_configs was called for model summary and integration version
+    assert run.log_configs.call_count >= 2
 
-    run.wait()
-    run.exists(f"{npt_logger.base_namespace}/batch/loss")
-    run.exists(f"{npt_logger.base_namespace}/model/checkpoints/checkpoint_1.pt")
-    run.exists(f"{npt_logger.base_namespace}/model/checkpoints/checkpoint_2.pt")
-    run.exists(f"{npt_logger.base_namespace}/model/model.pt")
-    run.exists(f"{npt_logger.base_namespace}/model/summary")
-    run.exists(f"{npt_logger.base_namespace}/model/visualization")
+    # Verify model summary was logged
+    log_configs_calls = run.log_configs.call_args_list
+    model_summary_calls = [
+        call for call in log_configs_calls if f"{npt_logger.base_namespace}/model/summary" in str(call)
+    ]
+    assert model_summary_calls, "Model summary should be logged"
+
+    # Verify model summary content and namespace
+    for call in model_summary_calls:
+        call_kwargs = call.kwargs
+        if "data" in call_kwargs:
+            summary_data = call_kwargs["data"]
+            expected_namespace = f"{npt_logger.base_namespace}/model/summary"
+            assert expected_namespace in summary_data, f"Model summary should be logged under {expected_namespace}"
+            # The summary should contain the model's string representation
+            assert isinstance(summary_data[expected_namespace], str), "Model summary should be a string"
+
+    # Verify diagram behavior
+    assign_files_calls = run.assign_files.call_args_list
+    diagram_calls = [call for call in assign_files_calls if "diagram" in str(call)]
+
+    assert run.assign_files.call_count >= 1, "Model diagram should be uploaded"
+    assert run.wait_for_processing.call_count >= 1, "Should wait for upload to complete"
+    assert diagram_calls, "Model diagram should be uploaded with correct namespace"
+
+    # Verify that model internals logging was called
+    # The TorchWatcher should have logged metrics for activations, gradients, and parameters
+    log_metrics_calls = run.log_metrics.call_args_list
+
+    # Check that we have calls for both batch loss and model internals
+    batch_loss_calls = [call for call in log_metrics_calls if f"{npt_logger.base_namespace}/batch/loss" in str(call)]
+    model_internals_calls = [call for call in log_metrics_calls if "model/internals" in str(call)]
+
+    assert batch_loss_calls, "Batch loss should be logged"
+    assert model_internals_calls, "Model internals should be logged"
+
+    # Verify that the model internals calls contain the expected namespace structure
+    for call in model_internals_calls:
+        call_kwargs = call.kwargs
+        if "data" in call_kwargs:
+            metrics = call_kwargs["data"]
+            for metric_name in metrics.keys():
+                assert metric_name.startswith(
+                    f"{npt_logger.base_namespace}/model/internals/"
+                ), f"Metric {metric_name} should start with correct namespace"
+                assert any(
+                    metric_type in metric_name for metric_type in ["activations", "gradients", "parameters"]
+                ), f"Metric {metric_name} should contain one of: activations, gradients, parameters"

--- a/tests/test_torchwatcher.py
+++ b/tests/test_torchwatcher.py
@@ -201,11 +201,11 @@ class TestTorchWatcher:
         # Forward pass to generate activations
         _ = test_model(test_data)
 
-        tw.track_activations()
+        metrics = tw.track_activations()
 
         # Check that activations were tracked
-        assert len(tw.debug_metrics) > 0
-        for key in tw.debug_metrics:
+        assert len(metrics) > 0
+        for key in metrics:
             assert key.startswith("test/model/internals/activations/")
             assert key.endswith(("/mean", "/norm"))
 
@@ -218,11 +218,11 @@ class TestTorchWatcher:
         loss = F.nll_loss(output, torch.randint(0, 10, (2,)))
         loss.backward()
 
-        tw.track_gradients()
+        metrics = tw.track_gradients()
 
         # Check that gradients were tracked
-        assert len(tw.debug_metrics) > 0
-        for key in tw.debug_metrics:
+        assert len(metrics) > 0
+        for key in metrics:
             assert key.startswith("test/model/internals/gradients/")
             assert key.endswith(("/mean", "/norm"))
 
@@ -235,11 +235,11 @@ class TestTorchWatcher:
             tensor_stats=["mean", "norm"],
         )
 
-        tw.track_parameters()
+        metrics = tw.track_parameters()
 
         # Check that parameters were tracked
-        assert len(tw.debug_metrics) > 0
-        for key in tw.debug_metrics:
+        assert len(metrics) > 0
+        for key in metrics:
             assert key.startswith("test/model/internals/parameters/")
             assert key.endswith(("/mean", "/norm"))
 
@@ -253,8 +253,8 @@ class TestTorchWatcher:
         )
 
         # Should log every time
-        tw.track_parameters()
-        assert len(tw.debug_metrics) > 0
+        metrics = tw.track_parameters()
+        assert len(metrics) > 0
 
     def test_watch_method(self, mock_run, test_model, test_data):
         """Test the main watch method."""
@@ -369,17 +369,16 @@ class TestTorchWatcher:
 
         # Test without prefix
         test_data = {"layer1": torch.tensor([1.0, 2.0])}
-        tw._track_metric("activations", test_data)
+        metrics = tw._track_metric("activations", test_data)
 
         expected_key = "test/model/internals/activations/layer1/mean"
-        assert expected_key in tw.debug_metrics
+        assert expected_key in metrics
 
         # Test with prefix
-        tw.debug_metrics.clear()
-        tw._track_metric("gradients", test_data, prefix="train")
+        metrics = tw._track_metric("gradients", test_data, prefix="train")
 
         expected_key = "test/model/internals/train/gradients/layer1/mean"
-        assert expected_key in tw.debug_metrics
+        assert expected_key in metrics
 
 
 class TestIntegration:

--- a/tests/test_torchwatcher.py
+++ b/tests/test_torchwatcher.py
@@ -1,0 +1,436 @@
+"""
+Comprehensive test suite for _TorchWatcher functionality.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from neptune_scale import Run
+
+from neptune_pytorch.impl._torchwatcher import (
+    TENSOR_STATS,
+    _HookManager,
+    _TorchWatcher,
+)
+
+
+class TestNet(nn.Module):
+    """Simple test network for testing TorchWatcher."""
+
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        return F.log_softmax(x, dim=1)
+
+
+@pytest.fixture
+def mock_run():
+    """Mock Neptune run object."""
+    run = Mock(spec=Run)
+    run.log_metrics = Mock()
+    run.log_histograms = Mock()
+    run.log_configs = Mock()
+    run.assign_files = Mock()
+    run.wait_for_processing = Mock()
+    return run
+
+
+@pytest.fixture
+def test_model():
+    """Test PyTorch model."""
+    return TestNet()
+
+
+@pytest.fixture
+def test_data():
+    """Test input data."""
+    return torch.rand(2, 1, 28, 28)
+
+
+class TestHookManager:
+    """Test _HookManager functionality."""
+
+    def test_hook_manager_initialization(self, test_model):
+        """Test HookManager initialization with valid model."""
+        hm = _HookManager(test_model)
+        assert hm.model == test_model
+        assert hm.track_layers is None
+        assert len(hm.hooks) == 0
+        assert len(hm.activations) == 0
+        assert len(hm.gradients) == 0
+
+    def test_hook_manager_with_specific_layers(self, test_model):
+        """Test HookManager with specific layer types."""
+        track_layers = [nn.Conv2d, nn.Linear]
+        hm = _HookManager(test_model, track_layers)
+        assert hm.track_layers == track_layers
+
+    def test_hook_manager_invalid_model(self):
+        """Test HookManager with invalid model type."""
+        with pytest.raises(TypeError, match="The model must be a PyTorch model"):
+            _HookManager("not_a_model")
+
+    def test_hook_manager_invalid_layer_types(self, test_model):
+        """Test HookManager with invalid layer types."""
+        with pytest.raises(ValueError, match="Invalid layer type"):
+            _HookManager(test_model, [str, int])
+
+    def test_register_hooks(self, test_model):
+        """Test hook registration."""
+        hm = _HookManager(test_model)
+        hm.register_hooks(track_activations=True, track_gradients=True)
+
+        # Should have hooks for all layers except the model itself
+        expected_hooks = len([name for name, _ in test_model.named_modules() if name != ""])
+        assert len(hm.hooks) == expected_hooks * 2  # activations + gradients
+
+    def test_register_hooks_activations_only(self, test_model):
+        """Test hook registration for activations only."""
+        hm = _HookManager(test_model)
+        hm.register_hooks(track_activations=True, track_gradients=False)
+
+        expected_hooks = len([name for name, _ in test_model.named_modules() if name != ""])
+        assert len(hm.hooks) == expected_hooks
+
+    def test_register_hooks_gradients_only(self, test_model):
+        """Test hook registration for gradients only."""
+        hm = _HookManager(test_model)
+        hm.register_hooks(track_activations=False, track_gradients=True)
+
+        expected_hooks = len([name for name, _ in test_model.named_modules() if name != ""])
+        assert len(hm.hooks) == expected_hooks
+
+    def test_remove_hooks(self, test_model):
+        """Test hook removal."""
+        hm = _HookManager(test_model)
+        hm.register_hooks()
+
+        hm.remove_hooks()
+        assert len(hm.hooks) == 0
+
+    def test_clear_data(self, test_model):
+        """Test clearing stored data."""
+        hm = _HookManager(test_model)
+        hm.activations["test"] = torch.tensor([1.0])
+        hm.gradients["test"] = torch.tensor([2.0])
+
+        hm.clear()
+        assert len(hm.activations) == 0
+        assert len(hm.gradients) == 0
+
+    def test_hook_manager_with_specific_layers_filtering(self, test_model):
+        """Test that specific layer filtering works correctly."""
+        track_layers = [nn.Conv2d]
+        hm = _HookManager(test_model, track_layers)
+        hm.register_hooks(track_activations=True, track_gradients=True)
+
+        # Should only have hooks for Conv2d layers
+        conv_layers = [
+            name for name, module in test_model.named_modules() if isinstance(module, nn.Conv2d) and name != ""
+        ]
+        expected_hooks = len(conv_layers) * 2  # activations + gradients
+        assert len(hm.hooks) == expected_hooks
+
+
+class TestTorchWatcher:
+    """Test _TorchWatcher functionality."""
+
+    def test_torch_watcher_initialization(self, mock_run, test_model):
+        """Test TorchWatcher initialization with valid parameters."""
+        tw = _TorchWatcher(
+            model=test_model,
+            run=mock_run,
+            base_namespace="test",
+            track_layers=None,
+            tensor_stats=["mean", "norm"],
+        )
+
+        assert tw.model == test_model
+        assert tw.run == mock_run
+        assert tw.base_namespace == "test"
+        assert "mean" in tw.tensor_stats
+        assert "norm" in tw.tensor_stats
+
+    def test_torch_watcher_default_parameters(self, mock_run, test_model):
+        """Test TorchWatcher with default parameters."""
+        tw = _TorchWatcher(model=test_model, run=mock_run, base_namespace="test")
+
+        assert tw.track_layers is None
+        assert tw.tensor_stats == {stat: TENSOR_STATS[stat] for stat in ["mean", "norm", "hist"]}
+
+    def test_torch_watcher_invalid_model(self, mock_run):
+        """Test TorchWatcher with invalid model type."""
+        with pytest.raises(TypeError, match="The model must be a PyTorch model"):
+            _TorchWatcher(model="not_a_model", run=mock_run, base_namespace="test")
+
+    def test_torch_watcher_invalid_tensor_stats(self, mock_run, test_model):
+        """Test TorchWatcher with invalid tensor statistics."""
+        with pytest.raises(ValueError, match="Invalid statistics requested"):
+            _TorchWatcher(
+                model=test_model,
+                run=mock_run,
+                base_namespace="test",
+                tensor_stats=["invalid_stat", "mean"],
+            )
+
+    def test_track_activations(self, mock_run, test_model, test_data):
+        """Test activation tracking."""
+        tw = _TorchWatcher(model=test_model, run=mock_run, base_namespace="test", tensor_stats=["mean", "norm"])
+
+        # Forward pass to generate activations
+        _ = test_model(test_data)
+
+        tw.track_activations()
+
+        # Check that activations were tracked
+        assert len(tw.debug_metrics) > 0
+        for key in tw.debug_metrics:
+            assert key.startswith("test/model/internals/activations/")
+            assert key.endswith(("/mean", "/norm"))
+
+    def test_track_gradients(self, mock_run, test_model, test_data):
+        """Test gradient tracking."""
+        tw = _TorchWatcher(model=test_model, run=mock_run, base_namespace="test", tensor_stats=["mean", "norm"])
+
+        # Forward and backward pass to generate gradients
+        output = test_model(test_data)
+        loss = F.nll_loss(output, torch.randint(0, 10, (2,)))
+        loss.backward()
+
+        tw.track_gradients()
+
+        # Check that gradients were tracked
+        assert len(tw.debug_metrics) > 0
+        for key in tw.debug_metrics:
+            assert key.startswith("test/model/internals/gradients/")
+            assert key.endswith(("/mean", "/norm"))
+
+    def test_track_parameters(self, mock_run, test_model):
+        """Test parameter tracking."""
+        tw = _TorchWatcher(
+            model=test_model,
+            run=mock_run,
+            base_namespace="test",
+            tensor_stats=["mean", "norm"],
+        )
+
+        tw.track_parameters()
+
+        # Check that parameters were tracked
+        assert len(tw.debug_metrics) > 0
+        for key in tw.debug_metrics:
+            assert key.startswith("test/model/internals/parameters/")
+            assert key.endswith(("/mean", "/norm"))
+
+    def test_track_parameters_always_logs(self, mock_run, test_model):
+        """Test parameter tracking always logs when called."""
+        tw = _TorchWatcher(
+            model=test_model,
+            run=mock_run,
+            base_namespace="test",
+            tensor_stats=["mean"],
+        )
+
+        # Should log every time
+        tw.track_parameters()
+        assert len(tw.debug_metrics) > 0
+
+    def test_watch_method(self, mock_run, test_model, test_data):
+        """Test the main watch method."""
+        tw = _TorchWatcher(model=test_model, run=mock_run, base_namespace="test", tensor_stats=["mean", "norm"])
+
+        # Forward and backward pass
+        output = test_model(test_data)
+        loss = F.nll_loss(output, torch.randint(0, 10, (2,)))
+        loss.backward()
+
+        tw.watch(step=0, track_activations=True, track_gradients=True, track_parameters=False)
+
+        # Check that metrics were logged
+        mock_run.log_metrics.assert_called_once()
+        call_args = mock_run.log_metrics.call_args
+        assert "step" in call_args.kwargs
+        assert call_args.kwargs["step"] == 0
+
+        # Verify that the logged data contains the expected metrics
+        logged_data = call_args.kwargs["data"]
+        assert len(logged_data) > 0, "Should have logged some metrics"
+
+        # Check that all logged metrics have the correct namespace structure
+        for metric_name in logged_data.keys():
+            assert metric_name.startswith(
+                "test/model/internals/"
+            ), f"Metric {metric_name} should start with correct namespace"
+            assert any(
+                metric_type in metric_name for metric_type in ["activations", "gradients"]
+            ), f"Metric {metric_name} should contain activations or gradients"
+            assert metric_name.endswith(("/mean", "/norm")), f"Metric {metric_name} should end with /mean or /norm"
+
+    def test_watch_method_with_prefix(self, mock_run, test_model, test_data):
+        """Test watch method with prefix."""
+        tw = _TorchWatcher(model=test_model, run=mock_run, base_namespace="test", tensor_stats=["mean"])
+
+        # Forward pass
+        _ = test_model(test_data)
+
+        tw.watch(step=0, track_activations=True, prefix="train")
+
+        # Check that metrics were logged with prefix
+        mock_run.log_metrics.assert_called_once()
+        call_args = mock_run.log_metrics.call_args
+        metrics = call_args.kwargs["data"]
+
+        # All metrics should have the prefix
+        for key in metrics:
+            assert key.startswith("test/model/internals/train/")
+
+    def test_histogram_processing(self, mock_run, test_model, test_data):
+        """Test histogram processing in watch method."""
+        tw = _TorchWatcher(model=test_model, run=mock_run, base_namespace="test", tensor_stats=["hist"])
+
+        # Forward pass
+        _ = test_model(test_data)
+
+        tw.watch(step=0, track_activations=True)
+
+        # Should call both log_metrics and log_histograms
+        mock_run.log_metrics.assert_called_once()
+        mock_run.log_histograms.assert_called_once()
+
+        # Verify log_histograms was called with correct parameters
+        hist_call_args = mock_run.log_histograms.call_args
+        assert "step" in hist_call_args.kwargs
+        assert hist_call_args.kwargs["step"] == 0
+
+        # Verify that histograms contain the expected structure
+        histograms = hist_call_args.kwargs["histograms"]
+        assert len(histograms) > 0, "Should have logged some histograms"
+
+        for hist_name, hist_data in histograms.items():
+            assert hist_name.startswith(
+                "test/model/internals/activations/"
+            ), f"Histogram {hist_name} should start with correct namespace"
+            assert hist_name.endswith("/hist"), f"Histogram {hist_name} should end with /hist"
+            assert hasattr(hist_data, "bin_edges"), "Histogram should have bin_edges"
+            assert hasattr(hist_data, "counts"), "Histogram should have counts"
+
+    def test_context_manager(self, mock_run, test_model):
+        """Test TorchWatcher as context manager."""
+        with _TorchWatcher(model=test_model, run=mock_run, base_namespace="test") as tw:
+            assert tw is not None
+            assert len(tw.hm.hooks) > 0
+
+        # Hooks should be removed after context exit
+        assert len(tw.hm.hooks) == 0
+
+    def test_safe_tensor_stats(self, mock_run, test_model):
+        """Test safe tensor statistics computation."""
+        tw = _TorchWatcher(
+            model=test_model,
+            run=mock_run,
+            base_namespace="test",
+            tensor_stats=["mean", "hist", "norm"],
+        )
+
+        test_tensor = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        stats = tw._safe_tensor_stats(test_tensor)
+
+        assert "mean" in stats
+        assert "hist" in stats
+        assert "norm" in stats
+        assert isinstance(stats["mean"], float)
+        assert isinstance(stats["hist"], torch.return_types.histogram)
+        assert isinstance(stats["norm"], float)
+
+    def test_track_metric_namespace_construction(self, mock_run, test_model):
+        """Test proper namespace construction in _track_metric."""
+        tw = _TorchWatcher(model=test_model, run=mock_run, base_namespace="test", tensor_stats=["mean"])
+
+        # Test without prefix
+        test_data = {"layer1": torch.tensor([1.0, 2.0])}
+        tw._track_metric("activations", test_data)
+
+        expected_key = "test/model/internals/activations/layer1/mean"
+        assert expected_key in tw.debug_metrics
+
+        # Test with prefix
+        tw.debug_metrics.clear()
+        tw._track_metric("gradients", test_data, prefix="train")
+
+        expected_key = "test/model/internals/train/gradients/layer1/mean"
+        assert expected_key in tw.debug_metrics
+
+
+class TestIntegration:
+    """Integration tests for TorchWatcher with NeptuneLogger."""
+
+    def test_neptune_logger_with_torch_watcher(self, mock_run, test_model, test_data):
+        """Test NeptuneLogger integration with TorchWatcher."""
+        from neptune_pytorch.impl import NeptuneLogger
+
+        logger = NeptuneLogger(
+            run=mock_run,
+            model=test_model,
+            base_namespace="integration_test",
+            tensor_stats=["mean", "norm"],
+        )
+
+        # Forward and backward pass
+        output = test_model(test_data)
+        loss = F.nll_loss(output, torch.randint(0, 10, (2,)))
+        loss.backward()
+
+        # Log model internals
+        logger.log_model_internals(
+            step=0,
+            prefix="test",
+            track_activations=True,
+            track_gradients=True,
+            track_parameters=True,
+        )
+
+        # Check that TorchWatcher was used
+        assert logger._torch_watcher is not None
+        mock_run.log_metrics.assert_called()
+
+    def test_neptune_logger_without_tracking(self, mock_run, test_model):
+        """Test NeptuneLogger with tracking disabled via log_model_internals."""
+        from neptune_pytorch.impl import NeptuneLogger
+
+        logger = NeptuneLogger(
+            run=mock_run,
+            model=test_model,
+        )
+
+        # Should have TorchWatcher
+        assert logger._torch_watcher is not None
+
+        # log_model_internals with all tracking disabled
+        logger.log_model_internals(step=0, track_activations=False, track_gradients=False, track_parameters=False)
+        # Should still call log_metrics but with no data
+        mock_run.log_metrics.assert_called()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_torchwatcher.py
+++ b/tests/test_torchwatcher.py
@@ -335,13 +335,13 @@ class TestTorchWatcher:
             assert hasattr(hist_data, "bin_edges"), "Histogram should have bin_edges"
             assert hasattr(hist_data, "counts"), "Histogram should have counts"
 
-    def test_context_manager(self, mock_run, test_model):
-        """Test TorchWatcher as context manager."""
-        with _TorchWatcher(model=test_model, run=mock_run, base_namespace="test") as tw:
-            assert tw is not None
-            assert len(tw.hm.hooks) > 0
+    def test_hook_cleanup_on_destruction(self, mock_run, test_model):
+        """Test that hooks are cleaned up when TorchWatcher is destroyed."""
+        tw = _TorchWatcher(model=test_model, run=mock_run, base_namespace="test")
+        assert len(tw.hm.hooks) > 0
 
-        # Hooks should be removed after context exit
+        # Manually call remove_hooks to test cleanup
+        tw.hm.remove_hooks()
         assert len(tw.hm.hooks) == 0
 
     def test_safe_tensor_stats(self, mock_run, test_model):


### PR DESCRIPTION
## Summary by Sourcery

Upgrade neptune-pytorch to support Neptune 3.x via neptune_scale and introduce a new TorchWatcher-based model internals tracking system

New Features:
- Add support for Neptune 3.x using neptune_scale.Run and drop older Neptune client support
- Implement TorchWatcher to log layer activations, gradients, and parameters with configurable statistics
- Introduce track_layers and tensor_stats options along with a new log_model_internals API
- Enable automatic model diagram generation and upload with assign_files and wait_for_processing

Enhancements:
- Refactor NeptuneLogger to simplify constructor, remove legacy hooks, and delegate internals logging to TorchWatcher
- Redesign namespace structure for model internals under {base_namespace}/model/internals/{prefix}/{metric_type}/{layer}/{statistic}
- Switch to importlib.metadata for versioning and require Python ≥3.10, PyTorch ≥1.11, NumPy ≥1.20

Build:
- Raise minimum Python requirement to 3.10 and bump dependencies (torch ≥1.11, numpy ≥1.20, neptune_scale ≥0.14.0) in pyproject.toml

CI:
- Expand CI matrix to run on Python 3.10 and 3.13
- Update pre-commit configuration to latest hook versions and add a pytest hook

Documentation:
- Overhaul README with installation instructions, quick start guide, advanced configuration, feature list, API reference, and namespace examples
- Update CHANGELOG for version 3.0.0 to document breaking changes and new capabilities
- Refresh pyproject.toml metadata, classifiers, and dependency declarations

Tests:
- Add a comprehensive test suite for _HookManager and _TorchWatcher functionality
- Update end-to-end tests to mock neptune_scale.Run and verify log_model_internals, log_configs, and file uploads